### PR TITLE
feature: custom logo.svg upload (repo.js, settings.jsx, publish.jsx)

### DIFF
--- a/packages/repo/src/repo.js
+++ b/packages/repo/src/repo.js
@@ -511,6 +511,22 @@ export class Repo {
     const { cid: newFilesRoot, unchangedCids: unchangedFileCids } = await this.files.stage()
     rootPointer = await this.unixfs.cp(newFilesRoot, rootPointer, FILES_FOLDER, { force: true })
 
+    /**
+     * *** icon upload ***
+     * If the user staged files under `/_assets/**` via Files (which live at `/_files/_assets/**`),
+     * we mirror that directory into the site root at `/_assets/**` so runtime paths like
+     * `/_assets/images/icon.svg` resolve correctly and the diff shows only that file change.
+     */
+    {
+      const filesTop = await ls(this.blockstore, newFilesRoot)
+      const stagedAssetsCid = filesTop.find(([name]) => name === '_assets')?.[1]
+      if (stagedAssetsCid) {
+        // Copy the entire _assets subtree into the site root
+        rootPointer = await this.unixfs.cp(stagedAssetsCid, rootPointer, '_assets', { force: true })
+      }
+    }
+    // *** icon upload ***
+
     // updates settings
     const newSettingsRoot = await this.settings.stage()
     rootPointer = await this.unixfs.cp(newSettingsRoot, rootPointer, SETTINGS_FILE, { force: true })


### PR DESCRIPTION
tried to allow a custom overwrite of _assets/images/logo.svg. 
<img width="1408" height="741" alt="Screenshot 2025-09-20 at 17 14 26" src="https://github.com/user-attachments/assets/65b8d800-24b1-47c5-b56a-ef9eadf5996e" />
<img width="1410" height="707" alt="Screenshot 2025-09-20 at 17 14 20" src="https://github.com/user-attachments/assets/49bd84cc-4f2a-47f5-bcbf-963dbae8a075" />
<img width="1411" height="715" alt="Screenshot 2025-09-20 at 17 12 17" src="https://github.com/user-attachments/assets/c47d3e26-32c5-4937-a70b-f8b70b2460d0" />

goal is to have the custom logo show on mobile homescreen. if that functionality was intended anyway, then this attempt might be useful...?


